### PR TITLE
feat: implement basic auth workflow #1

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,7 @@
 <template>
   <div>
-    <NuxtWelcome />
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
   </div>
 </template>

--- a/components/LogoutButton.vue
+++ b/components/LogoutButton.vue
@@ -1,0 +1,12 @@
+<script setup>
+const supabase = useSupabaseClient();
+
+const signOut = async () => {
+  const { error } = await supabase.auth.signOut();
+  if (error) console.log(error);
+  navigateTo('/login');
+};
+</script>
+<template>
+  <UButton @click="signOut">Signout</UButton>
+</template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,7 +5,7 @@ export default defineNuxtConfig({
     redirectOptions: {
       login: '/login',
       callback: '/confirm',
-      exclude: ['/'],
+      exclude: ['/', '/signup'],
     },
   },
 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,11 +1,16 @@
 export default defineNuxtConfig({
+  runtimeConfig: {
+    public: {
+      baseUrl: process.env.BASE_URL || 'http://localhost:3000',
+    },
+  },
   devtools: { enabled: true },
   modules: ['@nuxt/ui', '@nuxtjs/supabase'],
   supabase: {
     redirectOptions: {
       login: '/login',
       callback: '/confirm',
-      exclude: ['/', '/signup'],
+      exclude: ['/'],
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
-        "@nuxt/ui": "^2.12.0"
+        "@nuxt/ui": "^2.12.0",
+        "date-fns": "^3.3.1"
       },
       "devDependencies": {
         "@nuxtjs/supabase": "^1.1.5",
@@ -4641,6 +4642,15 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "vue-router": "^4.2.5"
   },
   "dependencies": {
-    "@nuxt/ui": "^2.12.0"
+    "@nuxt/ui": "^2.12.0",
+    "date-fns": "^3.3.1"
   }
 }

--- a/pages/confirm.vue
+++ b/pages/confirm.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+const user = useSupabaseUser();
+
+watch(
+  user,
+  () => {
+    if (user.value) {
+      return navigateTo('/today');
+    }
+  },
+  { immediate: true }
+);
+</script>
+
+<template>
+  <div>Waiting for login...</div>
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-const supabase = useSupabaseClient();
 const user = useSupabaseUser();
-
-const signOut = async () => {
-  const { error } = await supabase.auth.signOut();
-  if (error) console.log(error);
-};
-console.log(user);
 </script>
 <template>
+  <h1 class="font-bold text-xl">many a day</h1>
+  <span>A line a day</span>
   <div v-if="user">
-    <UButton @click="signOut">Signout</UButton>
+    <UButton
+      ><ULink to="/today"
+        >You're logged in. Go to your Diaries today!</ULink
+      ></UButton
+    >
+    <LogoutButton />
   </div>
-
-  <h1 class="font-bold text-xl">HELLO</h1>
+  <UButton v-else
+    ><ULink to="/login">You're not logged in, LOGIN!</ULink>
+  </UButton>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+const supabase = useSupabaseClient();
+const user = useSupabaseUser();
+
+const signOut = async () => {
+  const { error } = await supabase.auth.signOut();
+  if (error) console.log(error);
+};
+console.log(user);
+</script>
+<template>
+  <div v-if="user">
+    <UButton @click="signOut">Signout</UButton>
+  </div>
+
+  <h1 class="font-bold text-xl">HELLO</h1>
+</template>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { FormError, FormSubmitEvent } from '#ui/types';
+
+const supabase = useSupabaseClient();
+
+const state = reactive({
+  email: undefined,
+  password: undefined,
+});
+
+const onEmailLogin = async (event: FormSubmitEvent<any>) => {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: 'example@email.com',
+    password: 'example-password',
+  });
+};
+
+const validate = (state: any): FormError[] => {
+  const errors = [];
+  if (!state.email) errors.push({ path: 'email', message: 'Required' });
+  if (!state.password) errors.push({ path: 'password', message: 'Required' });
+  return errors;
+};
+</script>
+
+<template>
+  <div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <h2 class="my-6 text-center text-3xl font-extrabold u-text-white">
+      Sign in to your account
+    </h2>
+    <LoginCard>
+      <UForm :state="state" :validate="validate" @submit="onEmailLogin">
+        <UFormGroup label="Email" name="email">
+          <UInput v-model="state.email" />
+        </UFormGroup>
+        <UFormGroup label="Password" name="password">
+          <UInput v-model="state.password" type="password" />
+        </UFormGroup>
+        <UButton type="submit"> Login </UButton>
+      </UForm>
+      <UButton
+        class="mt-3"
+        icon="i-mdi-github"
+        block
+        label="Github"
+        @click="supabase.auth.signInWithOAuth({ provider: 'github' })"
+      />
+      <UButton
+        class="mt-3"
+        icon="i-mdi-google"
+        block
+        label="Google"
+        @click="supabase.auth.signInWithOAuth({ provider: 'google' })"
+      />
+    </LoginCard>
+  </div>
+</template>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -2,16 +2,29 @@
 import type { FormError, FormSubmitEvent } from '#ui/types';
 
 const supabase = useSupabaseClient();
+const user = useSupabaseUser();
 
+watchEffect(() => {
+  if (user.value) {
+    console.log('logged in');
+    navigateTo('/today');
+  }
+});
+
+// EMAIL LOGIN setup
+/*
 const state = reactive({
   email: undefined,
   password: undefined,
 });
 
 const onEmailLogin = async (event: FormSubmitEvent<any>) => {
+  if (!state.email || !state.password) {
+    return;
+  }
   const { data, error } = await supabase.auth.signInWithPassword({
-    email: 'example@email.com',
-    password: 'example-password',
+    email: state.email,
+    password: state.password,
   });
 };
 
@@ -21,6 +34,7 @@ const validate = (state: any): FormError[] => {
   if (!state.password) errors.push({ path: 'password', message: 'Required' });
   return errors;
 };
+*/
 </script>
 
 <template>
@@ -29,7 +43,7 @@ const validate = (state: any): FormError[] => {
       Sign in to your account
     </h2>
     <LoginCard>
-      <UForm :state="state" :validate="validate" @submit="onEmailLogin">
+      <!-- <UForm :state="state" :validate="validate" @submit="onEmailLogin">
         <UFormGroup label="Email" name="email">
           <UInput v-model="state.email" />
         </UFormGroup>
@@ -44,13 +58,20 @@ const validate = (state: any): FormError[] => {
         block
         label="Github"
         @click="supabase.auth.signInWithOAuth({ provider: 'github' })"
-      />
+      /> -->
       <UButton
         class="mt-3"
         icon="i-mdi-google"
         block
         label="Google"
-        @click="supabase.auth.signInWithOAuth({ provider: 'google' })"
+        @click="
+          supabase.auth.signInWithOAuth({
+            provider: 'google',
+            options: {
+              redirectTo: 'http://localhost:3000/confirm',
+            },
+          })
+        "
       />
     </LoginCard>
   </div>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { FormError, FormSubmitEvent } from '#ui/types';
-
+const runtimeConfig = useRuntimeConfig();
 const supabase = useSupabaseClient();
 const user = useSupabaseUser();
 
@@ -68,7 +68,7 @@ const validate = (state: any): FormError[] => {
           supabase.auth.signInWithOAuth({
             provider: 'google',
             options: {
-              redirectTo: 'http://localhost:3000/confirm',
+              redirectTo: `${runtimeConfig.public.baseUrl}/confirm`,
             },
           })
         "

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { FormError, FormSubmitEvent } from '#ui/types';
+
+const supabase = useSupabaseClient();
+
+const state = reactive({
+  email: undefined,
+  password: undefined,
+  passwordConfirm: undefined,
+  name: undefined,
+});
+
+const validate = (state: any): FormError[] => {
+  const errors = [];
+  if (!state.email) errors.push({ path: 'email', message: 'Required' });
+  if (!state.password) errors.push({ path: 'password', message: 'Required' });
+  if (!state.passwordConfirm)
+    errors.push({ path: 'passwordConfirm', message: 'Required' });
+  if (!state.name) errors.push({ path: 'name', message: 'Required' });
+  return errors;
+};
+
+const signupEmail = async () => {
+  const { data, error } = await supabase.auth.signUp({
+    email: state.email!,
+    password: state.password!,
+  });
+
+  console.log(data);
+};
+</script>
+
+<template>
+  <div class="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <h2 class="my-6 text-center text-3xl font-extrabold u-text-white">
+      Create your account
+    </h2>
+
+    <UForm :state="state" :validate="validate" @submit="signupEmail">
+      <UFormGroup label="Email" name="email">
+        <UInput v-model="state.email" type="email" />
+      </UFormGroup>
+      <UFormGroup label="Name" name="name">
+        <UInput v-model="state.name" type="text" />
+      </UFormGroup>
+      <UFormGroup label="Password" name="password">
+        <UInput v-model="state.password" type="password" />
+      </UFormGroup>
+      <UFormGroup label="Confirm Password" name="passwordConfirm">
+        <UInput v-model="state.passwordConfirm" type="password" />
+      </UFormGroup>
+      <UButton type="submit"> Signup </UButton>
+    </UForm>
+    <UButton
+      class="mt-3"
+      icon="i-mdi-github"
+      block
+      label="Github"
+      @click="supabase.auth.signInWithOAuth({ provider: 'github' })"
+    />
+  </div>
+</template>

--- a/pages/today.vue
+++ b/pages/today.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const date = ref(Date.now());
+</script>
+<template>
+  <h1>today is</h1>
+  <h2>[ {{ date }}]</h2>
+  <LogoutButton />
+  <p>Here are all the diaries from this MM-DD date.</p>
+</template>

--- a/supabase/db.sql
+++ b/supabase/db.sql
@@ -9,7 +9,7 @@ create table profiles (
   username text
 );
 alter table profiles enable row level security;
-create policy "Can view own account." on profiles for select using (auth.uid() = user_id);
+create policy "Can view own profile." on profiles for select using (auth.uid() = user_id);
 
 create policy "Users can insert their own profile."
   on profiles for insert

--- a/supabase/db.sql
+++ b/supabase/db.sql
@@ -1,0 +1,35 @@
+-- profiles
+create table profiles (
+  id uuid not null primary key default uuid_generate_v4(),
+  user_id uuid references auth.users on delete cascade  not null,
+  created_ts TIMESTAMP WITH TIME ZONE not null default now(),
+  updated_ts TIMESTAMP WITH TIME ZONE,
+  first_name text,
+  last_name text,
+  username text
+);
+alter table profiles enable row level security;
+create policy "Can view own account." on profiles for select using (auth.uid() = user_id);
+
+create policy "Users can insert their own profile."
+  on profiles for insert
+  with check ( auth.uid() = id );
+
+create policy "Users can update own profile."
+  on profiles for update
+  using ( auth.uid() = id );
+
+-- inserts a row into public.profiles
+create or replace function public.handle_new_user() 
+returns trigger as $$
+begin
+  insert into public.profiles (user_id, username)
+  values (new.id, new.email);
+  return new;
+end;
+$$ language plpgsql security definer;
+
+-- trigger the function everytime a user is created 
+create or replace trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();


### PR DESCRIPTION
- built login/logout feature utilizing useSupabaseClient & useSuperbaseUser composables 
- implement Google OAuth for login (also started github & email signin) -- for now will focus on one authentication method
- once auth flow is complete -> redirected to /confirm page, which reroutes to /today
- build signout button as reusable component
