### PR TITLE
feat: render posts from today's mm-dd on today page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Glass+Antiqua&family=Italiana&display=swap');
+
 body {
   margin-block-start: 2em;
   margin-block-end: 2em;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,4 +5,10 @@ body {
   margin-block-end: 2em;
   margin-inline-start: 2em;
   margin-inline-end: 2em;
+
+  background-color: hsl(0, 0%, 85%);
+}
+
+h1 {
+  color: hsl(223, 100%, 50%);
 }

--- a/components/EntryUnit.vue
+++ b/components/EntryUnit.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+defineProps({
+  content: String,
+  createdAt: String,
+});
+</script>
+<template>
+  <section>
+    <h3>{{ extractYear(createdAt!) }}</h3>
+    <div>{{ content }}</div>
+  </section>
+</template>
+
+<style scoped>
+h3 {
+  font-size: 2rem;
+  font-family: 'Glass Antiqua';
+}
+
+div {
+  background-color: hotpink;
+  padding: 20px;
+}
+</style>

--- a/pages/today.vue
+++ b/pages/today.vue
@@ -30,3 +30,10 @@ const { data: entries } = await useAsyncData('entries', async () => {
     </li>
   </ul>
 </template>
+
+<style>
+h1 {
+  font-family: 'Italiana';
+  font-size: 3rem;
+}
+</style>

--- a/pages/today.vue
+++ b/pages/today.vue
@@ -25,8 +25,7 @@ const { data: entries } = await useAsyncData('entries', async () => {
   <p>Here are all the diaries from {{ format(date, 'MMMM do') }}.</p>
   <ul>
     <li v-for="entry in entries" :key="entry.id">
-      <h3>{{ extractYear(entry.created_ts) }}</h3>
-      {{ entry.content }}
+      <EntryUnit :content="entry.content" :createdAt="entry.created_ts" />
     </li>
   </ul>
 </template>

--- a/pages/today.vue
+++ b/pages/today.vue
@@ -1,11 +1,32 @@
 <script setup lang="ts">
 import { format } from 'date-fns';
+import type { Database } from '@/types/database.types';
+const user = useSupabaseUser();
+const supabase = useSupabaseClient<Database>();
 
 const date = Date.now();
+const user_id = user.value!.id;
+
+const monthDay = extractMonthDay(date);
+const { data: entries } = await useAsyncData('entries', async () => {
+  const { data } = await supabase
+    .from('entries')
+    .select()
+    .eq('user_id', user_id)
+    .eq('month_day', monthDay)
+    .order('created_ts', { ascending: false });
+  return data;
+});
 </script>
 <template>
-  <h1>today is</h1>
-  <h2>{{ format(date, 'MMM do, yyy') }}</h2>
+  <h2>{{ upperCase('today is') }}</h2>
+  <h1>{{ `[[  ${formatMmDdYyyy(date)}  ]]` }}</h1>
   <LogoutButton />
-  <p>Here are all the diaries from this MM-DD date.</p>
+  <p>Here are all the diaries from {{ format(date, 'MMMM do') }}.</p>
+  <ul>
+    <li v-for="entry in entries" :key="entry.id">
+      <h3>{{ extractYear(entry.created_ts) }}</h3>
+      {{ entry.content }}
+    </li>
+  </ul>
 </template>

--- a/pages/write.vue
+++ b/pages/write.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { FormError, FormSubmitEvent } from '#ui/types';
-import type { Database } from '@/types/database.types';
 import { format } from 'date-fns';
+import type { Database } from '@/types/database.types';
 
 const supabase = useSupabaseClient<Database>();
 const user = useSupabaseUser();
@@ -62,8 +62,9 @@ const createEntry = async (event: FormSubmitEvent<any>) => {
       <span
         >writing a post for
         <UButton
+          class="date"
           icon="i-heroicons-calendar-days-20-solid"
-          :label="'[ [  ' + format(entry.date, 'MMM do, yyy') + '  ] ]'"
+          :label="'[ [  ' + formatMmDdYyyy(entry.date.getTime()) + '  ] ]'"
       /></span>
       <template #panel="{ close }">
         <DatePicker v-model="entry.date" @close="close" />
@@ -86,3 +87,11 @@ const createEntry = async (event: FormSubmitEvent<any>) => {
     <UButton type="submit"> Publish </UButton>
   </UForm>
 </template>
+
+<style>
+.date {
+  font-family: 'Italiana';
+  font-size: 1.5rem;
+  padding: 15px;
+}
+</style>

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,0 +1,13 @@
+import { format } from 'date-fns';
+
+export const extractMonthDay = (date: number) => {
+  return format(date, 'MM-dd');
+};
+
+export const formatMmDdYyyy = (date: number) => {
+  return format(date, 'MMM do, yyy');
+};
+
+export const extractYear = (created_ts: string) => {
+  return created_ts.slice(0, 4);
+};

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -1,0 +1,1 @@
+export const upperCase = (str: string) => str.toUpperCase();


### PR DESCRIPTION
Pretty straight forward PR today: 

- closes #10 
- Created functions dealing with date-formatting using date-fns library in `utils/` folder for reusability and taking advantage of Nuxt's auto-import feature

- Used `useAsyncData` to grab entries from database that had today's `month-day` and belonged to the current user. 
- Had the database in reverse chronological order (from most recent year to older years). 
![CleanShot 2024-02-28 at 12 02 09@2x](https://github.com/boyeonihn/manyaday/assets/95451902/2bcacbe7-5ff1-44dc-8f94-54a92ca1fb1b)
- created "entryUnit" component for the list rendering on the today page. 
- applied some global css styling (e.g. background color, font styling). 


One question is: 
![CleanShot 2024-02-28 at 12 11 12@2x](https://github.com/boyeonihn/manyaday/assets/95451902/d4c0158d-fe5d-4b58-a2df-2f765bcde9c3)
I found myself constantly having to re-type the follow code regarding importing database type as well as declaring `supabase` using `useSupabaseClient()` function and putting `<Database>` as type across multiple pages (e.g. today page, write page, etc). Is there a way to "componentify" this code so that I can reuse it simply by importing `supabase`? 
- Also wasn't sure which folder in the Nuxt 3 directory I would put this code (e.g. chatGPT sometimes said the utils, composables folder so wasn't too clear) 
(tl;dr - I'm tired of having to assign <Database> type everytime I use `useSupabaseClient()`)