### PR TITLE
feat: modify public.profiles table and RLS policy 

### DIFF
--- a/composables/useProfile.ts
+++ b/composables/useProfile.ts
@@ -1,0 +1,11 @@
+export const useProfile = async () => {
+  const user = useUser();
+  const supabase = useSupabase();
+  const { data } = await supabase
+    .from('profiles')
+    .select()
+    .eq('user_id', user.value.id)
+    .single();
+
+  return data;
+};

--- a/composables/useProfileByUsername.ts
+++ b/composables/useProfileByUsername.ts
@@ -1,6 +1,6 @@
-export const useUserByUsername = async (username: string) => {
+export const useProfileByUsername = async (username: string) => {
   const nuxtApp = useNuxtApp();
-  const key = `user-by-username-${username}`;
+  const key = `profile-by-username-${username}`;
   const handler = async () => {
     const supabase = useSupabase();
     const { data, error } = await supabase
@@ -17,10 +17,6 @@ export const useUserByUsername = async (username: string) => {
 
   const options = {
     getCachedData: (key: string) => {
-      // console.log('✨ cached', {
-      //   key,
-      //   cached: nuxtApp.payload.data[key] || nuxtApp.static.data[key],
-      // });
       return nuxtApp.isHydrating
         ? nuxtApp.payload.data[key]
         : nuxtApp.static.data[key];

--- a/composables/useUserByUsername.ts
+++ b/composables/useUserByUsername.ts
@@ -2,7 +2,6 @@ export const useUserByUsername = async (username: string) => {
   const nuxtApp = useNuxtApp();
   const key = `user-by-username-${username}`;
   const handler = async () => {
-    console.log(`🌙 fetcher function being called for ${username}`);
     const supabase = useSupabase();
     const { data, error } = await supabase
       .from('profiles')
@@ -10,7 +9,6 @@ export const useUserByUsername = async (username: string) => {
       .eq('username', username)
       .single();
 
-    console.log('trying to get supabase data');
     if (data) {
       return data;
     }

--- a/pages/[username]/[mmdd].vue
+++ b/pages/[username]/[mmdd].vue
@@ -3,6 +3,14 @@ let {
   params: { mmdd, username },
 } = useRoute();
 
+const supabase = useSupabase();
+const user = useUser();
+const { data: loggedUser } = await supabase
+  .from('profiles')
+  .select('username')
+  .eq('user_id', user.value.id)
+  .single();
+
 const monthDay = `${mmdd.slice(0, 2)}-${mmdd.slice(2)}`;
 username = typeof username === 'string' ? username : username[0];
 
@@ -26,6 +34,7 @@ definePageMeta({
 });
 </script>
 <template>
+  <p>logged in user: {{ loggedUser!.username }}</p>
   <h1>{{ username }}'s entries for {{ monthDay }}</h1>
   <ul>
     <li v-for="entry in entries" :key="entry.id">

--- a/pages/[username]/[mmdd].vue
+++ b/pages/[username]/[mmdd].vue
@@ -3,14 +3,7 @@ let {
   params: { mmdd, username },
 } = useRoute();
 
-const supabase = useSupabase();
-const user = useUser();
-const { data: loggedUser } = await supabase
-  .from('profiles')
-  .select('username')
-  .eq('user_id', user.value.id)
-  .single();
-
+const loggedUser = await useProfile();
 const monthDay = `${mmdd.slice(0, 2)}-${mmdd.slice(2)}`;
 username = typeof username === 'string' ? username : username[0];
 
@@ -34,7 +27,7 @@ definePageMeta({
 });
 </script>
 <template>
-  <p>logged in user: {{ loggedUser!.username }}</p>
+  <p v-if="loggedUser">logged in user: {{ loggedUser.username }}</p>
   <h1>{{ username }}'s entries for {{ monthDay }}</h1>
   <ul>
     <li v-for="entry in entries" :key="entry.id">

--- a/pages/[username]/[mmdd].vue
+++ b/pages/[username]/[mmdd].vue
@@ -16,7 +16,7 @@ username = typeof username === 'string' ? username : username[0];
 
 // TODO: refactor code by creating another composable that integrates INNER JOIN to fetch entries
 // with username and mmdd (without having two requests userid, and then entries)
-const { data } = await useUserByUsername(username);
+const { data } = await useProfileByUsername(username);
 if (!data.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page Not Found' });
 }

--- a/supabase/db.sql
+++ b/supabase/db.sql
@@ -96,3 +96,10 @@ begin
   return substring(email from '([^@]+)') || '-' || substring(md5(random()::text || clock_timestamp()::text)::text from 1 for 4);
 end
 $$ language plpgsql security definer; 
+
+-- update RLS policy on public.profiles
+alter policy "Can view own profile." on profiles rename to "Can view profile and other users' public profiles."
+
+alter policy "Can view profile and other users' public profiles." on profiles for 
+select
+  using (is_public = true or auth.uid() = user_id)

--- a/supabase/db.sql
+++ b/supabase/db.sql
@@ -4,9 +4,8 @@ create table profiles (
   user_id uuid references auth.users on delete cascade  not null,
   created_ts TIMESTAMP WITH TIME ZONE not null default now(),
   updated_ts TIMESTAMP WITH TIME ZONE,
-  username text,
-  last_name text, 
-  first_name text
+  username text
+  is_public boolean not null default false 
 );
 
 alter table profiles enable row level security;
@@ -90,12 +89,6 @@ create index idx_month_day ON public.entries("month_day")
 -- if I want to change the index I have to drop it first 
 -- drop index idx_month_day ON public.entries
 
--- alter structure of profiles 
-alter table profiles
-  drop first_name,
-  drop last_name,
-  add email text
-
 -- extract username from email upon user signup
 create or replace function public.generate_username(email TEXT)
 returns TEXT as $$
@@ -103,8 +96,3 @@ begin
   return substring(email from '([^@]+)') || '-' || substring(md5(random()::text || clock_timestamp()::text)::text from 1 for 4);
 end
 $$ language plpgsql security definer; 
-
-
--- alter structure of profiles table
-alter table profiles
-  add is_public boolean not null default false 

--- a/supabase/db.sql
+++ b/supabase/db.sql
@@ -1,5 +1,5 @@
 -- profiles
-create or alter table profiles (
+create table profiles (
   id uuid not null primary key default uuid_generate_v4(),
   user_id uuid references auth.users on delete cascade  not null,
   created_ts TIMESTAMP WITH TIME ZONE not null default now(),
@@ -103,3 +103,8 @@ begin
   return substring(email from '([^@]+)') || '-' || substring(md5(random()::text || clock_timestamp()::text)::text from 1 for 4);
 end
 $$ language plpgsql security definer; 
+
+
+-- alter structure of profiles table
+alter table profiles
+  add is_public boolean not null default false 


### PR DESCRIPTION
- closes #18 
- added `is_public` column to `public.profiles` as well as modified RLS policy for `select` - users can now view own profile or other public profiles.

- as shown in screenshot, `boyeondev` user can visit another public profile user `boyeonihndfd8`'s public entry page:
![CleanShot 2024-05-08 at 17 25 02](https://github.com/boyeonihn/manyaday/assets/95451902/0c4f0373-d123-4194-a4eb-9beda2f89001)
- and of course, `boyeondev` user can visit their own entry page:
![CleanShot 2024-05-08 at 17 26 44](https://github.com/boyeonihn/manyaday/assets/95451902/ba2a8cc2-cbed-497a-85c9-18d77fd2afb8)


question: 
- I realized a feature I want is to display current logged in user's info (e.g. maybe I want a message at the top of the header, `hello, username!`), so I wrote the code below: 
![CleanShot 2024-05-08 at 17 23 13](https://github.com/boyeonihn/manyaday/assets/95451902/c0b78266-2d8f-420f-97be-d4f56c65644a)
- Now looking at this code.. it looks preettty similar to `useUserByUsername` composable. The difference is that for the current logged in user code, I get the user info by utilizing `useUser` composable (which uses `useSupabaseUser` under the hood) -> then using useUser's user_id info -> make a fetch request to `profiles` table. 
![CleanShot 2024-05-08 at 17 28 56](https://github.com/boyeonihn/manyaday/assets/95451902/7be154ed-57e1-40c8-b249-bdf67c1ba748)

- Now my question is... I can foresee me potentially needing to get current logged in user's info quite often (e.g. edit profile/settings page, perhaps using it on layouts page to always have 'hello, boyeondev!' display on the header, etc). Which makes me think having a composable for this purpose make sense. 
- Is it meaningful to expand/generalize useUserByUsername composable so that we can get user data by passing username OR user_id? OR is it wiser in this situation to perhaps make a separate composable useLoggedinUser? 
